### PR TITLE
Define Read Configuration Utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "medibioticsai"
-version = "0.1.2"
+version = "0.1.3"
 description = "MediBioticsAI is a cutting-edge initiative at the forefront of the healthcare revolution, harnessing the power of AI&ML to address some of the most pressing challenges in the field of health and medicine."
 authors = ["Simone Porreca <porrecasimone@gmail.com>"]
 license = "GPL-3.0"

--- a/src/general_utils/general_utils.py
+++ b/src/general_utils/general_utils.py
@@ -1,0 +1,49 @@
+"""
+The module contains several general util functions
+"""
+# Import Standard Libraries
+import os
+from pathlib import Path
+import yaml
+
+
+# Import Package Modules
+from src.logging_module.logging_module import get_logger
+
+# Setup logger
+logger = get_logger(os.path.basename(__file__).split('.')[0],
+                    Path(__file__).parents[2] / 'configuration' / 'log_configuration.yaml')
+
+
+def read_configuration(file_name: str) -> dict:
+    """
+    Read and return the specified configuration file from the 'configuration' folder
+
+    Args:
+        file_name: String configuration file name to read
+
+    Returns:
+        configuration: Dictionary configuration
+    """
+
+    logger.info('read_configuration - Start')
+
+    try:
+
+        logger.info('read_configuration - Reading %s', file_name)
+
+        # Read configuration file
+        with open(Path(__file__).parents[2] / 'configuration' / file_name,
+                  encoding='utf-8') as config_file:
+
+            configuration = yaml.safe_load(config_file.read())
+
+    except FileNotFoundError as exc:
+
+        raise FileNotFoundError(f'read_data - File {file_name} not found') from exc
+
+    logger.info('read_configuration - Configuration file %s read successfully', file_name)
+
+    logger.info('read_configuration - End')
+
+    return configuration

--- a/src/tests/test_general_utils.py
+++ b/src/tests/test_general_utils.py
@@ -1,0 +1,53 @@
+"""
+This test module includes all the tests for the
+module src.general.general_utils
+"""
+# Import Standard Modules
+import pytest
+
+# Import Package Modules
+from src.general_utils.general_utils import read_configuration
+
+
+@pytest.mark.parametrize('test_config_file, test_config, expected_value', [
+    ('config.yaml', 'test_value', 1),
+])
+def test_read_configuration(test_config_file: str,
+                            test_config: str,
+                            expected_value: int):
+    """
+    Test the function src.general_utils.general_utils.read_configuration
+    by reading test configuration entries
+
+    Args:
+        test_config_file: String configuration file name
+        test_config: String configuration entry key
+        expected_value: String configuration expected value
+
+    Returns:
+    """
+
+    # Read configuration file
+    config = read_configuration(test_config_file)
+
+    assert config[test_config] == expected_value
+
+
+@pytest.mark.parametrize('test_config_file, expected_error', [
+    ('wrong_config.yaml', FileNotFoundError)
+])
+def test_read_configuration_exception(test_config_file: str,
+                                      expected_error: FileNotFoundError):
+    """
+    Test the exceptions to the function src.general_utils.general_utils.read_configuration
+
+    Args:
+        test_config_file: String wrong configuration file name
+        expected_error: Exception instance
+
+    Returns:
+    """
+
+    with pytest.raises(expected_error):
+
+        read_configuration(test_config_file)


### PR DESCRIPTION
# Description
This PR resolves the issue #7 by adding a function `read_configuration` in the `general_utils` module.

# Changelog
- [x] Add `general_utils/general_utils.py`
- [x] Define the `read_configuration` function
- [x] Add `tests/test_general_utils.py`
- [x] Define the `test_read_configuration`
- [x] Define the `test_read_configuration_exception`
- [x] Update the wiki
- [x] Update the readme
- [x] Update Package version